### PR TITLE
Fixed bug in IntegrityActions that handled null fields incorrectly

### DIFF
--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -46,11 +46,11 @@ namespace IntegrityActions {
 
 	public:
 		// ChangePackage specific functionality
-		std::wstring getId() { return m_id; }
-		std::wstring getSumamry() { return m_summary; }
-		std::wstring getDescription() { return m_description; }
-		std::wstring getType() { return m_cptype; }
-		std::wstring getIssueId() { return m_issueId; }
+		std::wstring getId() const { return m_id; } 
+		std::wstring getSumamry() const { return m_summary; } 
+		std::wstring getDescription() const { return m_description; } 
+		std::wstring getType() const { return m_cptype; }
+		std::wstring getIssueId() const { return m_issueId; }
 	};
 
 	class ChangePackage::ChangePackageBuilder {

--- a/src/Integrity/IntegrityResponse.cpp
+++ b/src/Integrity/IntegrityResponse.cpp
@@ -24,24 +24,32 @@
 
 std::wstring getExceptionMessage(mksAPIException exception) {
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
+
 	mksAPIExceptionGetMessage(exception, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);
 }
 
 std::wstring getId(mksAPIException exception) {
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
+
 	mksAPIExceptionGetId(exception, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);
 }
 
 std::wstring getId(mksWorkItem item) {
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
+
 	mksWorkItemGetId(item, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);
 }
 
 std::wstring getModelType(mksWorkItem item) {
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
+
 	mksWorkItemGetModelType(item, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);
 }
@@ -49,6 +57,7 @@ std::wstring getModelType(mksWorkItem item) {
 std::wstring getStringFieldValue(mksWorkItem item, const std::wstring& fieldName) {
 	mksField field = mksWorkItemGetField(item, (wchar_t*)fieldName.c_str());
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
 
 	mksFieldGetStringValue(field, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);
@@ -57,6 +66,7 @@ std::wstring getStringFieldValue(mksWorkItem item, const std::wstring& fieldName
 std::wstring getStringFieldValue(mksItem item, const std::wstring& fieldName) {
 	mksField field = mksItemGetField(item, (wchar_t*)fieldName.c_str());
 	wchar_t buffer[DEFAULT_BUFFER_SIZE];
+	buffer[0] = '\0';
 
 	mksFieldGetStringValue(field, buffer, DEFAULT_BUFFER_SIZE);
 	return std::wstring(buffer);


### PR DESCRIPTION
Affects any integrity action which returned a null field
